### PR TITLE
Pro 2279 allow records updates

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -8,7 +8,27 @@ module.exports = (self) => {
         reporting.setTotal(pieces.length);
       }
 
-      const [ piecesToImport, convertErr ] = await self.convertPieces(req, pieces);
+      const [ updateKey, updateKeyErr ] = self.checkIfUpdateKey(pieces[0], file.path);
+
+      if (updateKeyErr) {
+        return await self.stopProcess(req, {
+          message: updateKeyErr,
+          filePath: file.path
+        });
+      }
+
+      const fieldUpdate = updateKey.replace(':key', '');
+
+      const [ piecesToImport, convertErr ] = await self.convertPieces(req, {
+        pieces,
+        fieldUpdate,
+        updateKey
+      });
+
+      // return await self.stopProcess(req, {
+      //   message: 'ta mere',
+      //   filePath: file.path
+      // });
 
       if (convertErr.length) {
         return await self.stopProcess(req, {
@@ -17,7 +37,11 @@ module.exports = (self) => {
         });
       }
 
-      const importedCount = await self.importPieces(req, piecesToImport, reporting);
+      const importedCount = await self.importOrUpdatePieces(req, {
+        piecesToImport,
+        reporting,
+        fieldUpdate
+      });
 
       return await self.stopProcess(req, {
         message: 'Imported {{ count }} {{ type }}.',
@@ -49,16 +73,26 @@ module.exports = (self) => {
       }
     },
 
-    async convertPieces (req, pieces) {
+    async convertPieces (req, {
+      pieces, fieldUpdate, updateKey
+    }) {
       const piecesToImport = [];
       const convertErr = [];
 
       for (const [ i, piece ] of pieces.entries()) {
         const csvLine = i + 2;
         try {
+          if (updateKey) {
+            piece[fieldUpdate] = piece[updateKey];
+            delete piece[updateKey];
+          }
 
           const converted = {};
           await self.apos.schema.convert(req, self.schema, piece, converted);
+
+          if (converted[fieldUpdate]) {
+            converted.toUpdate = true;
+          }
 
           piecesToImport.push(converted);
         } catch (errors) {
@@ -95,12 +129,19 @@ module.exports = (self) => {
       }
     },
 
-    async importPieces (req, pieces, reporting) {
+    async importOrUpdatePieces (req, {
+      pieces, reporting, fieldUpdate
+    }) {
       let importedCount = 0;
 
       for (const piece of pieces) {
         try {
-          await self.insert(req, piece);
+          if (piece.toUpdate) {
+            delete piece.toUpdate;
+            await self.update(req, piece);
+          } else {
+            await self.insert(req, piece);
+          }
 
           reporting.success();
           importedCount++;
@@ -110,6 +151,15 @@ module.exports = (self) => {
       }
 
       return importedCount;
+    },
+
+    checkIfUpdateKey (piece) {
+      const [ key, ...rest ] = Object.keys(piece)
+        .filter((key) => key.match(/:key$/));
+
+      return !rest.length
+        ? [ key, null ]
+        : [ null, 'You can have only one :key column for updates.' ];
     }
   };
 };

--- a/lib/import.js
+++ b/lib/import.js
@@ -8,7 +8,10 @@ module.exports = (self) => {
         reporting.setTotal(pieces.length);
       }
 
-      const [ updateKey, updateKeyErr ] = self.checkIfUpdateKey(pieces[0], file.path);
+      const {
+        updateKey, updateField, updateKeyErr
+      } = self
+        .checkIfUpdateKey(pieces[0], file.path);
 
       if (updateKeyErr) {
         return await self.stopProcess(req, {
@@ -17,18 +20,11 @@ module.exports = (self) => {
         });
       }
 
-      const fieldUpdate = updateKey.replace(':key', '');
-
       const [ piecesToImport, convertErr ] = await self.convertPieces(req, {
         pieces,
-        fieldUpdate,
+        updateField,
         updateKey
       });
-
-      // return await self.stopProcess(req, {
-      //   message: 'ta mere',
-      //   filePath: file.path
-      // });
 
       if (convertErr.length) {
         return await self.stopProcess(req, {
@@ -37,17 +33,24 @@ module.exports = (self) => {
         });
       }
 
-      const importedCount = await self.importOrUpdatePieces(req, {
-        piecesToImport,
+      const {
+        imported, updated
+      } = await self.importOrUpdatePieces(req, {
+        pieces: piecesToImport,
         reporting,
-        fieldUpdate
+        updateField,
+        existingFields: Object.keys(pieces[0])
       });
+      const importMsg = 'Imported {{ importedCount }} {{ typeImported }}. ';
+      const updateMsg = 'Updated {{ updatedCount }} {{ typeUpdated }}.';
 
       return await self.stopProcess(req, {
-        message: 'Imported {{ count }} {{ type }}.',
+        message: `${imported ? importMsg : ''}${updated ? updateMsg : ''}`,
         interpolate: {
-          count: importedCount,
-          type: req.t(importedCount <= 1 ? self.label : self.pluralLabel)
+          importedCount: imported,
+          updatedCount: updated,
+          typeImported: req.t(imported <= 1 ? self.label : self.pluralLabel),
+          typeUpdated: req.t(updated <= 1 ? self.label : self.pluralLabel)
         },
         filePath: file.path,
         type: 'success'
@@ -74,7 +77,7 @@ module.exports = (self) => {
     },
 
     async convertPieces (req, {
-      pieces, fieldUpdate, updateKey
+      pieces, updateField, updateKey
     }) {
       const piecesToImport = [];
       const convertErr = [];
@@ -83,20 +86,25 @@ module.exports = (self) => {
         const csvLine = i + 2;
         try {
           if (updateKey) {
-            piece[fieldUpdate] = piece[updateKey];
+            piece[updateField] = piece[updateKey];
             delete piece[updateKey];
           }
 
           const converted = {};
-          await self.apos.schema.convert(req, self.schema, piece, converted);
 
-          if (converted[fieldUpdate]) {
+          const hasUpdateKeyField = updateKey && piece[updateField];
+
+          await self.convert(req, piece, converted, { presentFieldsOnly: hasUpdateKeyField });
+
+          delete converted.copyOfId;
+
+          if (hasUpdateKeyField) {
             converted.toUpdate = true;
           }
 
           piecesToImport.push(converted);
         } catch (errors) {
-          if (convertErr.length < 10) {
+          if (Array.isArray(errors) && convertErr.length < 10) {
             errors.forEach((err) => {
               convertErr.push(`On line ${csvLine}, field ${err.path} is ${err.message}`);
             });
@@ -130,36 +138,50 @@ module.exports = (self) => {
     },
 
     async importOrUpdatePieces (req, {
-      pieces, reporting, fieldUpdate
+      pieces, reporting, updateField, existingFields
     }) {
-      let importedCount = 0;
+      const counter = {
+        imported: 0,
+        updated: 0
+      };
 
       for (const piece of pieces) {
         try {
           if (piece.toUpdate) {
             delete piece.toUpdate;
-            await self.update(req, piece);
+            const searchValue = piece[updateField];
+
+            await self.apos.doc.db.findOneAndUpdate({
+              _id: /:draft$/,
+              [updateField]: searchValue
+            }, {
+              $set: piece
+            });
+            counter.updated++;
           } else {
             await self.insert(req, piece);
+            counter.imported++;
           }
 
           reporting.success();
-          importedCount++;
         } catch (err) {
           reporting.failure();
         }
       }
 
-      return importedCount;
+      return counter;
     },
 
     checkIfUpdateKey (piece) {
-      const [ key, ...rest ] = Object.keys(piece)
+      const [ updateKey, ...rest ] = Object.keys(piece)
         .filter((key) => key.match(/:key$/));
 
       return !rest.length
-        ? [ key, null ]
-        : [ null, 'You can have only one :key column for updates.' ];
+        ? {
+          updateKey,
+          updateField: updateKey && updateKey.replace(':key', '')
+        }
+        : { updateKeyErr: 'You can have only one :key column for updates.' };
     }
   };
 };

--- a/test/data/csv/articles.csv
+++ b/test/data/csv/articles.csv
@@ -1,4 +1,4 @@
-title,seoTitle
-Article 1,first article
-Article 2,second article
-Article 3,third article
+title,category
+Article 1,book
+Article 2,film
+Article 3,toy

--- a/test/data/csv/articlesBad.csv
+++ b/test/data/csv/articlesBad.csv
@@ -1,4 +1,4 @@
-title,seoTitle
-Article 1,first article,,,
-Article 2,second article
-Article 3,third article
+title,category
+Article 1,book,,,
+Article 2,film
+Article 3,toy

--- a/test/data/csv/articlesMissingFields.csv
+++ b/test/data/csv/articlesMissingFields.csv
@@ -1,4 +1,4 @@
-title,seoTitle
-Article 1,first article
-,second article
+title,category
+Article 1,book
+,film
 Article 3,

--- a/test/data/csv/updateArticles.csv
+++ b/test/data/csv/updateArticles.csv
@@ -1,0 +1,4 @@
+title:key,category
+Article 1,clothes
+Article 2,makeup
+Article 3,toy

--- a/test/data/csv/updateMultipleKeysArtices.csv
+++ b/test/data/csv/updateMultipleKeysArtices.csv
@@ -1,0 +1,4 @@
+title:key,category:key
+Article 1,clothes
+Article 2,makeup
+Article 3,toy

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,12 @@ const path = require('path');
 const testUtil = require('apostrophe/test-lib/test');
 
 describe('Pieces Importer', function () {
+  const goodCsvPath = path.join(process.cwd(), 'test/data/csv/articles.csv');
+  const badCsvPath = path.join(process.cwd(), 'test/data/csv/articlesBad.csv');
+  const missingFieldsCsvPath = path.join(process.cwd(), 'test/data/csv/articlesMissingFields.csv');
+  const updateCsvPath = path.join(process.cwd(), 'test/data/csv/updateArticles.csv');
+  const updateMultipleKeysPath = path.join(process.cwd(), 'test/data/csv/updateMultipleKeysArtices.csv');
+
   let apos;
 
   after(async () => {
@@ -11,7 +17,7 @@ describe('Pieces Importer', function () {
 
   this.timeout(10000);
 
-  it('should improve piece types on the apos object', async () => {
+  it('Should improve piece types on the apos object', async () => {
     apos = await testUtil.create({
       shortname: 'test-importer',
       testModule: true,
@@ -41,11 +47,8 @@ describe('Pieces Importer', function () {
           },
           fields: {
             add: {
-              richText: {
-                type: 'area',
-                widgets: {
-                  '@apostrophecms/rich-text': {}
-                }
+              category: {
+                type: 'string'
               }
             }
           }
@@ -59,13 +62,11 @@ describe('Pieces Importer', function () {
     assert(articleModule.options.import === true);
   });
 
-  const goodCsvPath = path.join(process.cwd(), 'test/data/csv/articles.csv');
-  const badCsvPath = path.join(process.cwd(), 'test/data/csv/articlesBad.csv');
-  const missingFieldsCsvPath = path.join(process.cwd(), 'test/data/csv/articlesMissingFields.csv');
-
   let piecesFromCsv;
-  it('should get pieces from a csv file', async () => {
+  it('Should get pieces from a csv file', async () => {
     const [ pieces, parsingErr ] = await apos.modules.article.parseCsvFile(goodCsvPath);
+
+    assert(pieces.length === 3);
 
     piecesFromCsv = pieces;
 
@@ -74,16 +75,16 @@ describe('Pieces Importer', function () {
     assert(!parsingErr);
 
     assert(article1.title === 'Article 1');
-    assert(article1.seoTitle === 'first article');
+    assert(article1.category === 'book');
 
     assert(article2.title === 'Article 2');
-    assert(article2.seoTitle === 'second article');
+    assert(article2.category === 'film');
 
     assert(article3.title === 'Article 3');
-    assert(article3.seoTitle === 'third article');
+    assert(article3.category === 'toy');
   });
 
-  it('should return an error if the csv file is badly formatted', async () => {
+  it('Should return an error if the csv file is badly formatted', async () => {
     const [ pieces, parsingErr ] = await apos.modules.article.parseCsvFile(badCsvPath);
 
     assert(!pieces);
@@ -91,8 +92,9 @@ describe('Pieces Importer', function () {
     assert(parsingErr.message === 'Invalid Record Length: columns length is 2, got 5 on line 2');
   });
 
-  it('should insert pieces from the read file', async () => {
+  it('Should convert and insert pieces from the read file', async () => {
     const req = apos.task.getReq();
+    const self = apos.modules.article;
 
     let success = 0;
     let failures = 0;
@@ -106,16 +108,22 @@ describe('Pieces Importer', function () {
       }
     };
 
-    const self = apos.modules.article;
+    const [ piecesToImport, convertErr ] = await self.convertPieces(req, { pieces: piecesFromCsv });
 
-    const importedCount = await self.importPieces(req, piecesFromCsv, reporting);
+    assert(!convertErr.length);
 
-    assert(importedCount === 3);
+    const { imported, updated } = await self.importOrUpdatePieces(req, {
+      pieces: piecesToImport,
+      reporting
+    });
+
+    assert(imported === 3);
+    assert(updated === 0);
     assert(success === 3);
     assert(failures === 0);
   });
 
-  it('should fail to insert pieces if some cannot be converted', async () => {
+  it('Should fail to insert pieces if some cannot be converted', async () => {
     const req = apos.task.getReq();
     const self = apos.modules.article;
 
@@ -124,10 +132,96 @@ describe('Pieces Importer', function () {
     assert(!parsingErr);
     assert(pieces.length === 3);
 
-    const [ piecesToImport, convertErr ] = await self.convertPieces(req, pieces);
+    const [ piecesToImport, convertErr ] = await self.convertPieces(req, { pieces });
 
     assert(piecesToImport.length === 2);
     assert(convertErr.length === 1);
     assert(convertErr[0] === 'On line 3, field title is required');
+  });
+
+  it('Should update existing pieces if a :key suffix is added to a field', async () => {
+    const req = apos.task.getReq();
+    const self = apos.modules.article;
+
+    let success = 0;
+    let failures = 0;
+
+    const reporting = {
+      success: function () {
+        success++;
+      },
+      failure: function () {
+        failures++;
+      }
+    };
+
+    const [ pieces, parsingErr ] = await self.parseCsvFile(updateCsvPath);
+
+    assert(!parsingErr);
+    assert(pieces.length === 3);
+
+    const {
+      updateKey, updateField, updateKeyErr
+    } = self
+      .checkIfUpdateKey(pieces[0], '');
+
+    assert(!updateKeyErr);
+    assert(updateKey);
+    assert(updateField);
+
+    const [ piecesToImport, convertErr ] = await self.convertPieces(req, {
+      pieces,
+      updateField,
+      updateKey
+    });
+
+    assert(!convertErr.length);
+    assert(piecesToImport.length === 3);
+
+    const { imported, updated } = await self.importOrUpdatePieces(req, {
+      pieces: piecesToImport,
+      reporting,
+      updateField,
+      existingFields: Object.keys(pieces[0])
+    });
+
+    assert(imported === 0);
+    assert(updated === 3);
+    assert(success === 3);
+    assert(failures === 0);
+
+    const articles = await apos.doc.db.find({ _id: /:draft/ }).toArray();
+
+    articles.forEach((article) => {
+      switch (article.title) {
+        case 'Article 1':
+          assert(article.category === 'clothes');
+          break;
+
+        case 'Article 2':
+          assert(article.category === 'makeup');
+          break;
+
+        case 'Article 3':
+          assert(article.category === 'toy');
+          break;
+      }
+    });
+  });
+
+  it('It should stop the update process if must than one field contains a :key suffix.', async () => {
+    const self = apos.modules.article;
+
+    const [ pieces, parsingErr ] = await self.parseCsvFile(updateMultipleKeysPath);
+
+    assert(!parsingErr);
+    assert(pieces.length === 3);
+
+    const {
+      updateKeyErr
+    } = self
+      .checkIfUpdateKey(pieces[0], '');
+
+    assert(updateKeyErr);
   });
 });


### PR DESCRIPTION
[PRO-2279](https://linear.app/apostrophecms/issue/PRO-2279/as-an-editor-i-can-import-a-file-with-the-intent-of-updating-records)

## Purpose
Adds udpate feature for CSV imports similar of what is existing in the `apostrophe-pieces-import` modules in A2.
[See The doc here](https://github.com/apostrophecms/apostrophe-pieces-import#updating-existing-pieces).
Adds tests to check this new update feature.

## How to test
Test to import csv files with a `:key` field suffix (you can only have one otherwise you'll see an error).
For each piece it should update the piece based on the update key field. If this field is empty and authorized (by the convert method), then the piece is just inserted and not updated.

Here is an example of file.
[arts.csv](https://github.com/apostrophecms/piece-type-importer/files/7563267/arts.csv)

⚠️ Since the convert method was broken, it won't work without the fix of this PR: https://github.com/apostrophecms/apostrophe/pull/3549

