### PR TITLE
dismiss progress bar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Gets the progress notification from the `run` method, uses it to dismiss the progress notification if needed (early errors).
+
 ## 1.0.0-beta
 
 * Setup module, adds pieces import feature for CSV files, based on the `piece-type-exporter` module. It uses the A3 job system.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Gets the progress notification from the `run` method, uses it to dismiss the progress notification if needed (early errors).
+* Gets the progress notification ID from the `run` method, uses it to dismiss the progress notification if needed (early errors).
 
 ## 1.0.0-beta
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,9 @@ module.exports = {
 
             return self.apos.modules['@apostrophecms/job'].run(
               req,
-              (req, reporting) => self.importRun(req, reporting, {
+              (req, reporting, notification) => self.importRun(req, {
+                reporting,
+                notification,
                 file,
                 pieces
               }),

--- a/index.js
+++ b/index.js
@@ -70,9 +70,9 @@ module.exports = {
 
             return self.apos.modules['@apostrophecms/job'].run(
               req,
-              (req, reporting, notification) => self.importRun(req, {
+              (req, reporting, { notificationId }) => self.importRun(req, {
+                progressNotifId: notificationId,
                 reporting,
-                notification,
                 file,
                 pieces
               }),

--- a/lib/import.js
+++ b/lib/import.js
@@ -6,7 +6,12 @@ const joinErrors = (errors) => errors
 
 module.exports = (self) => {
   return {
-    async importRun (req, reporting, { file, pieces }) {
+    async importRun (req, {
+      reporting,
+      notification,
+      file,
+      pieces
+    }) {
       if (typeof reporting.setTotal === 'function') {
         reporting.setTotal(pieces.length);
       }
@@ -18,7 +23,8 @@ module.exports = (self) => {
       if (updateKeyErr) {
         return await self.importStopProcess(req, {
           message: updateKeyErr,
-          filePath: file.path
+          filePath: file.path,
+          progressNotif: notification
         });
       }
 
@@ -31,7 +37,8 @@ module.exports = (self) => {
       if (convertErr.length) {
         return await self.importStopProcess(req, {
           message: joinErrors(convertErr),
-          filePath: file.path
+          filePath: file.path,
+          progressNotif: notification
         });
       }
 
@@ -121,8 +128,13 @@ module.exports = (self) => {
       message,
       interpolate = {},
       filePath,
-      dismiss = true
+      dismiss = true,
+      progressNotif
     }) {
+      if (progressNotif) {
+        await self.apos.notification.dismiss(req, progressNotif.noteId, 0);
+      }
+
       await self.apos.notification.trigger(req, message, {
         interpolate,
         dismiss,

--- a/lib/import.js
+++ b/lib/import.js
@@ -220,7 +220,7 @@ module.exports = (self) => {
           updateKey,
           updateField: updateKey && updateKey.replace(':key', '')
         }
-        : { updateKeyErr: 'You can have only one :key column for updates.' };
+        : { updateKeyErr: 'You can have only one key column for updates.' };
     }
   };
 };

--- a/lib/import.js
+++ b/lib/import.js
@@ -7,8 +7,8 @@ const joinErrors = (errors) => errors
 module.exports = (self) => {
   return {
     async importRun (req, {
+      progressNotifId,
       reporting,
-      notification,
       file,
       pieces
     }) {
@@ -24,7 +24,7 @@ module.exports = (self) => {
         return await self.importStopProcess(req, {
           message: updateKeyErr,
           filePath: file.path,
-          progressNotif: notification
+          progressNotifId
         });
       }
 
@@ -38,7 +38,7 @@ module.exports = (self) => {
         return await self.importStopProcess(req, {
           message: joinErrors(convertErr),
           filePath: file.path,
-          progressNotif: notification
+          progressNotifId
         });
       }
 
@@ -129,10 +129,10 @@ module.exports = (self) => {
       interpolate = {},
       filePath,
       dismiss = true,
-      progressNotif
+      progressNotifId
     }) {
-      if (progressNotif) {
-        await self.apos.notification.dismiss(req, progressNotif.noteId, 0);
+      if (progressNotifId) {
+        await self.apos.notification.dismiss(req, progressNotifId, 0);
       }
 
       await self.apos.notification.trigger(req, message, {


### PR DESCRIPTION
[PRO-2283](https://linear.app/apostrophecms/issue/PRO-2283/as-an-editor-if-theres-an-error-with-my-job-it-should-cause-my)

## Purpose
Gets the progress notification  from the `run` method, uses it to dismiss the progress notification if needed (early errors)

## How to test
Should be test with [this PR](https://github.com/apostrophecms/apostrophe/pull/3570).
Try to import csv file with errors, it can be errors from badly formatted file, or missing fields for an import.
You can use the csv files provided:

[badlyFormatted.csv](https://github.com/apostrophecms/piece-type-importer/files/7634319/badlyFormatted.csv)
[missingFields.csv](https://github.com/apostrophecms/piece-type-importer/files/7634326/missingFields.csv)


