### PR TITLE
Pro 2400 Import from stream to avoid RAM saturation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "globals": {
     "apos": true
   },
+  "env": {
+    "mocha": true
+  },
   "overrides": [
     {
       "files": [

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unrealesed
+
+* Performs imports and updates through the stream, piece by piece to avoid overloading the RAM.
+
 ## 1.0.0-beta.1 - 2021-12-08
 
 * Gets the progress notification ID from the `run` method, uses it to dismiss the progress notification if needed (early errors).

--- a/index.js
+++ b/index.js
@@ -54,17 +54,19 @@ module.exports = {
               throw self.apos.error('invalid');
             }
 
-            const [ pieces, parsingErr ] = await self.importParseCsvFile(file.path);
+            // const [ pieces, parsingErr ] = await self.importParseCsvFile(file.path);
 
-            if (parsingErr) {
-              await self.importStopProcess(req, {
-                message: parsingErr.message,
-                filePath: file.path,
-                dismiss: false
-              });
+            const totalPieces = await self.countFileLines(file.path);
 
-              throw self.apos.error('invalid');
-            }
+            // if (parsingErr) {
+            //   await self.importStopProcess(req, {
+            //     message: parsingErr.message,
+            //     filePath: file.path,
+            //     dismiss: false
+            //   });
+
+            //   throw self.apos.error('invalid');
+            // }
 
             req.body = { messages: req.body };
 
@@ -74,7 +76,7 @@ module.exports = {
                 progressNotifId: notificationId,
                 reporting,
                 file,
-                pieces
+                totalPieces
               }),
               {}
             );

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = {
               throw self.apos.error('invalid');
             }
 
-            const totalPieces = await self.countFileLines(file.path);
+            const totalPieces = await self.importCountFileLines(file.path);
 
             req.body = { messages: req.body };
 

--- a/index.js
+++ b/index.js
@@ -54,19 +54,7 @@ module.exports = {
               throw self.apos.error('invalid');
             }
 
-            // const [ pieces, parsingErr ] = await self.importParseCsvFile(file.path);
-
             const totalPieces = await self.countFileLines(file.path);
-
-            // if (parsingErr) {
-            //   await self.importStopProcess(req, {
-            //     message: parsingErr.message,
-            //     filePath: file.path,
-            //     dismiss: false
-            //   });
-
-            //   throw self.apos.error('invalid');
-            // }
 
             req.body = { messages: req.body };
 
@@ -74,8 +62,8 @@ module.exports = {
               req,
               (req, reporting, { notificationId }) => self.importRun(req, {
                 progressNotifId: notificationId,
+                filePath: file.path,
                 reporting,
-                file,
                 totalPieces
               }),
               {}

--- a/lib/import.js
+++ b/lib/import.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const csvParse = require('csv-parse');
+const readline = require('readline');
 
 const joinErrors = (errors) => errors
   .join(' ') + (errors.length === 10 ? '..' : '');
@@ -10,7 +11,7 @@ module.exports = (self) => {
       progressNotifId,
       reporting,
       file,
-      pieces
+      totalPieces
     }) {
       if (typeof reporting.setTotal === 'function') {
         reporting.setTotal(pieces.length);
@@ -28,19 +29,19 @@ module.exports = (self) => {
         });
       }
 
-      const convertErr = await self.importCheckForConvertErrors(req, {
-        pieces,
-        updateKey,
-        updateField
-      });
+      // const convertErr = await self.importCheckForConvertErrors(req, {
+      //   pieces,
+      //   updateKey,
+      //   updateField
+      // });
 
-      if (convertErr.length) {
-        return await self.importStopProcess(req, {
-          message: joinErrors(convertErr),
-          filePath: file.path,
-          progressNotifId
-        });
-      }
+      // if (convertErr.length) {
+      //   return await self.importStopProcess(req, {
+      //     message: joinErrors(convertErr),
+      //     filePath: file.path,
+      //     progressNotifId
+      //   });
+      // }
 
       const {
         imported, updated, failed, errors
@@ -73,6 +74,23 @@ module.exports = (self) => {
         },
         filePath: file.path,
         type: !failed ? 'success' : 'warning'
+      });
+    },
+
+    async countFileLines (filePath) {
+      return new Promise((resolve, reject) => {
+        let linesCount = -1;
+        const rl = readline.createInterface({
+          input: fs.createReadStream(filePath),
+          output: process.stdout,
+          terminal: false
+        });
+        rl.on('line', () => {
+          linesCount++;
+        });
+        rl.on('close', () => {
+          resolve(linesCount);
+        });
       });
     },
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -20,7 +20,7 @@ module.exports = (self) => {
 
       const {
         imported, updated, failed, errors, processedErr
-      } = await self.processStream(req, {
+      } = await self.importProcessStream(req, {
         filePath: filePath,
         reporting
       });
@@ -59,7 +59,7 @@ module.exports = (self) => {
       });
     },
 
-    async countFileLines (filePath) {
+    async importCountFileLines (filePath) {
       return new Promise((resolve, reject) => {
         let linesCount = -1;
         const rl = readline.createInterface({
@@ -76,7 +76,7 @@ module.exports = (self) => {
       });
     },
 
-    async processStream (req, { filePath, reporting }) {
+    async importProcessStream (req, { filePath, reporting }) {
       try {
         const parser = fs
           .createReadStream(filePath)
@@ -146,7 +146,7 @@ module.exports = (self) => {
           errors
         };
       } catch (processedErr) {
-        return { processedErr };
+        return { processedErr: processedErr.message };
       }
     },
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -91,8 +91,7 @@ module.exports = (self) => {
         };
 
         let processed = 0;
-        let updateKey;
-        let updateField;
+        let updateKey, updateField;
         const errors = [];
 
         for await (const piece of parser) {

--- a/lib/import.js
+++ b/lib/import.js
@@ -26,7 +26,7 @@ module.exports = (self) => {
       });
 
       if (processedErr) {
-        await self.importStopProcess(req, {
+        return await self.importStopProcess(req, {
           message: processedErr,
           filePath: filePath,
           progressNotifId
@@ -96,7 +96,7 @@ module.exports = (self) => {
         const errors = [];
 
         for await (const piece of parser) {
-          const csvLine = processed + 1;
+          const csvLine = processed + 2;
 
           if (!processed) {
             const { key, field } = self.importCheckIfUpdateKey(piece, filePath);
@@ -122,8 +122,6 @@ module.exports = (self) => {
             }
 
             reporting.success();
-
-            processed++;
           } catch (err) {
             if (errors.length < 10) {
               if (Array.isArray(err)) {

--- a/lib/import.js
+++ b/lib/import.js
@@ -9,48 +9,30 @@ module.exports = (self) => {
   return {
     async importRun (req, {
       progressNotifId,
+      filePath,
       reporting,
-      file,
       totalPieces
     }) {
+
       if (typeof reporting.setTotal === 'function') {
-        reporting.setTotal(pieces.length);
+        reporting.setTotal(totalPieces);
       }
 
       const {
-        updateKey, updateField, updateKeyErr
-      } = self.importCheckIfUpdateKey(pieces[0], file.path);
+        imported, updated, failed, errors, processedErr
+      } = await self.processStream(req, {
+        filePath: filePath,
+        reporting
+      });
 
-      if (updateKeyErr) {
-        return await self.importStopProcess(req, {
-          message: updateKeyErr,
-          filePath: file.path,
+      if (processedErr) {
+        await self.importStopProcess(req, {
+          message: processedErr,
+          filePath: filePath,
           progressNotifId
         });
       }
 
-      // const convertErr = await self.importCheckForConvertErrors(req, {
-      //   pieces,
-      //   updateKey,
-      //   updateField
-      // });
-
-      // if (convertErr.length) {
-      //   return await self.importStopProcess(req, {
-      //     message: joinErrors(convertErr),
-      //     filePath: file.path,
-      //     progressNotifId
-      //   });
-      // }
-
-      const {
-        imported, updated, failed, errors
-      } = await self.importOrUpdatePieces(req, {
-        pieces,
-        reporting,
-        updateField,
-        updateKey
-      });
       const importMsg = 'Imported {{ importedCount }} {{ typeImported }}. ';
       const updateMsg = 'Updated {{ updatedCount }} {{ typeUpdated }}. ';
       const failMsg = '{{ failedCount }} failed.';
@@ -72,7 +54,7 @@ module.exports = (self) => {
           typeImported: req.t(imported <= 1 ? self.label : self.pluralLabel),
           typeUpdated: req.t(updated <= 1 ? self.label : self.pluralLabel)
         },
-        filePath: file.path,
+        filePath: filePath,
         type: !failed ? 'success' : 'warning'
       });
     },
@@ -85,7 +67,7 @@ module.exports = (self) => {
           output: process.stdout,
           terminal: false
         });
-        rl.on('line', () => {
+        rl.on('line', (line) => {
           linesCount++;
         });
         rl.on('close', () => {
@@ -94,51 +76,78 @@ module.exports = (self) => {
       });
     },
 
-    async importParseCsvFile (filePath) {
+    async processStream (req, { filePath, reporting }) {
       try {
-        const records = [];
         const parser = fs
           .createReadStream(filePath)
           .pipe(csvParse({
             columns: true
           }));
 
-        for await (const record of parser) {
-          records.push(record);
-        }
+        const counter = {
+          imported: 0,
+          updated: 0,
+          failed: 0
+        };
 
-        return [ records, null ];
-      } catch (err) {
-        return [ null, err ];
-      }
-    },
+        let processed = 0;
+        let updateKey;
+        let updateField;
+        const errors = [];
 
-    async importCheckForConvertErrors (req, {
-      pieces, updateKey, updateField
-    }) {
-      const convertErr = [];
+        for await (const piece of parser) {
+          const csvLine = processed + 1;
 
-      for (const [ i, piece ] of pieces.entries()) {
-        const csvLine = i + 2;
-        try {
-          const inputPiece = updateField && !piece[updateField]
-            ? {
-              ...piece,
-              [updateField]: piece[updateKey]
-            }
-            : piece;
+          if (!processed) {
+            const { key, field } = self.importCheckIfUpdateKey(piece, filePath);
 
-          await self.convert(req, inputPiece, {});
-        } catch (errors) {
-          if (Array.isArray(errors) && convertErr.length < 10) {
-            errors.forEach((err) => {
-              convertErr.push(`On line ${csvLine}, field ${err.path} is ${err.message}.`);
-            });
+            updateKey = key;
+            updateField = field;
           }
-        }
-      }
 
-      return convertErr;
+          try {
+            const action = await self.importOrUpdatePiece(req, {
+              piece,
+              csvLine,
+              updateKey,
+              updateField
+            });
+
+            if (action === 'imported') {
+              counter.imported++;
+            }
+
+            if (action === 'updated') {
+              counter.updated++;
+            }
+
+            reporting.success();
+
+            processed++;
+          } catch (err) {
+            if (errors.length < 10) {
+              if (Array.isArray(err)) {
+                err.forEach(({ path, message }) => {
+                  errors.push(`On line ${csvLine}, field ${path} is ${message}.`);
+                });
+              } else {
+                errors.push(err.message);
+              }
+            }
+            counter.failed++;
+            reporting.failure();
+          }
+
+          processed++;
+        }
+
+        return {
+          ...counter,
+          errors
+        };
+      } catch (processedErr) {
+        return { processedErr };
+      }
     },
 
     async importStopProcess (req, {
@@ -168,77 +177,55 @@ module.exports = (self) => {
       }
     },
 
-    async importOrUpdatePieces (req, {
-      pieces, reporting, updateKey, updateField
+    async importOrUpdatePiece (req, {
+      piece,
+      csvLine,
+      updateKey,
+      updateField
     }) {
-      const counter = {
-        imported: 0,
-        updated: 0,
-        failed: 0
-      };
-      const errors = [];
+      const updateKeyValue = updateKey && piece[updateKey];
 
-      for (const [ i, piece ] of pieces.entries()) {
-        try {
-          const csvLine = i + 2;
-          const updateKeyValue = updateKey && piece[updateKey];
+      if (!updateKeyValue) {
+        const pieceToImport = {};
 
-          if (!updateKeyValue) {
-            const pieceToImport = {};
+        await self.convert(req, piece, pieceToImport);
+        await self.insert(req, pieceToImport);
 
-            await self.convert(req, piece, pieceToImport);
-            await self.insert(req, pieceToImport);
-
-            counter.imported++;
-            reporting.success();
-            continue;
-          }
-
-          const existingPiece = await self.findForEditing(req, {
-            aposMode: 'draft',
-            [updateField]: updateKeyValue
-          }).toObject();
-
-          if (!existingPiece) {
-            throw new Error(`No ${self.label} found with ${
-              updateField} set to ${updateKeyValue} on line ${csvLine}.`);
-          }
-
-          if (!piece[updateField]) {
-            piece[updateField] = updateKeyValue;
-          }
-
-          await self.convert(req, piece, existingPiece);
-          await self.update(req, existingPiece);
-
-          counter.updated++;
-          reporting.success();
-
-        } catch (err) {
-          if (errors.length < 10) {
-            errors.push(err.message);
-          }
-          counter.failed++;
-          reporting.failure();
-        }
+        return 'imported';
       }
 
-      return {
-        ...counter,
-        errors
-      };
+      const existingPiece = await self.findForEditing(req, {
+        aposMode: 'draft',
+        [updateField]: updateKeyValue
+      }).toObject();
+
+      if (!existingPiece) {
+        throw new Error(`No ${self.label} found with ${
+            updateField} set to ${updateKeyValue} on line ${csvLine}.`);
+      }
+
+      if (!piece[updateField]) {
+        piece[updateField] = updateKeyValue;
+      }
+
+      await self.convert(req, piece, existingPiece);
+      await self.update(req, existingPiece);
+
+      return 'updated';
     },
 
     importCheckIfUpdateKey (piece) {
-      const [ updateKey, ...rest ] = Object.keys(piece)
+      const [ key, ...rest ] = Object.keys(piece)
         .filter((key) => key.match(/:key$/));
 
-      return !rest.length
-        ? {
-          updateKey,
-          updateField: updateKey && updateKey.replace(':key', '')
-        }
-        : { updateKeyErr: 'You can have only one key column for updates.' };
+      if (rest.length) {
+        throw new Error('You can have only one key column for updates.');
+      }
+
+      return {
+        key,
+        field: key && key.replace(':key', '')
+      };
     }
   };
 };

--- a/test/data/csv/articlesMissingFields.csv
+++ b/test/data/csv/articlesMissingFields.csv
@@ -1,4 +1,4 @@
 title,category
-Article 1,book
+,book
 ,film
-Article 3,
+,

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,8 @@ describe('Pieces Importer', function () {
   const updateCsvPath = path.join(process.cwd(), 'test/data/csv/updateArticles.csv');
   const updateMultipleKeysPath = path.join(process.cwd(), 'test/data/csv/updateMultipleKeysArtices.csv');
 
+  this.timeout(10000);
+
   let apos, self, req;
 
   let success, failures, reporting;


### PR DESCRIPTION
[PRO-2400](https://linear.app/apostrophecms/issue/PRO-2400)

## Summary

processing csv imports item by item through the stream to avoid RAM saturation.
We basically do the same thing because we was already converting and importing/updating item by item.
Now we set the total of items to import simply by reading the number of lines in the file.
Also, now of the csv is badly formatted it will stop the import before to start anything, but not for converts errors since we convert item by item.
We still have notifications about how many items has been imported / updated or failed. If some failed, why they did.

## What are the specific steps to test this change?

> 1. Npm link this module in the testbed project. (or another)
> 2. Run the website and log in as an admin
> 3. Open a piece manager modal and click the import button
> 4. Test to import pieces using csv files, try files badly formatted or with missing fields. It should work like before (except for convert errors as explained above)
> 5. Check that pieces has been successfully imported or updated.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated
