### PR TITLE
add csv to label

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Change label to "Import from CSV" to avoid confusion with the new [`@apostrophecms/import-export`](https://github.com/apostrophecms/import-export) module.
+
 ## 1.1.1 - 2023-08-03
 
 * Strip the UTF-8 BOM from CSV files. Otherwise the name of the first column is not correctly parsed.

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
       ? {
         add: {
           import: {
-            label: 'Import {{ type }}',
+            label: 'Import from CSV',
             modalOptions: {
               title: 'Import {{ type }}',
               description: 'Importing pieces requires a csv file with matching properties.',


### PR DESCRIPTION
## Summary

Related to https://github.com/apostrophecms/import-export/pull/50

Change the label to avoid confusion with the new `@apostrophecms/import-export` module:

![image](https://github.com/apostrophecms/piece-type-importer/assets/8301962/374c1fbd-aad5-4b62-abd1-cbf10b278bd2)
